### PR TITLE
added '--store' to missing commands

### DIFF
--- a/docs/carbide-charts.md
+++ b/docs/carbide-charts.md
@@ -73,20 +73,20 @@ EOF
 
 # fetch the content from generated hauler manifest
 # verify the version and the platform/architecture
-hauler store sync --files carbide-charts.yaml --store carbide-store --platform <platform/arch>
+hauler store sync --store carbide-store --files carbide-charts.yaml --platform <platform/arch>
 
 # save and output the content from the hauler store to tarball
-hauler store save --filename carbide-charts.tar.zst
+hauler store save --store carbide-store --filename carbide-charts.tar.zst
 ```
 
 #### On Airgapped Environment
 
 ```bash
 # load the content from the tarball to the hauler store
-hauler store load carbide-charts.tar.zst
+hauler store load --store carbide-store carbide-charts.tar.zst
 
 # server the content from the hauler store
-hauler store serve fileserver
+hauler store serve fileserver --store carbide-store
 
 # example install of a helm chart
 helm install <release-name> http://<FQDN or IP>:<PORT>/<chart>.tgz

--- a/docs/registry-docs/copying-images.md
+++ b/docs/registry-docs/copying-images.md
@@ -38,7 +38,7 @@ EOF
 
 # fetch the content from generated hauler manifest
 # verify the location of the key and the platform/architecture
-# key verification is not used here due to Natsio images not being signed
+# key verification is not used here due to natsio images not being signed
 hauler store sync --store carbide-store --files carbide-images.yaml --platform <platform/arch>
 
 # copy the content from the hauler store to your registry

--- a/docs/registry-docs/copying-images.md
+++ b/docs/registry-docs/copying-images.md
@@ -41,7 +41,7 @@ EOF
 hauler store sync --files carbide-images.yaml --store carbide-store --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store carbide-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ## K3s
@@ -58,7 +58,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 hauler store sync --products k3s=v1.27.12-k3s1 --key carbide-key.pub --store k3s-store --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store k3s-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ## RKE2
@@ -75,7 +75,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 hauler store sync --products rke2=v1.27.12+rke2r1 --key carbide-key.pub --store rke2-store --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store rke2-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ## Rancher
@@ -94,7 +94,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 hauler store sync --products cert-manager=v1.14.4 --key carbide-key.pub --store certmanager-store --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store certmanager-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ### Rancher
@@ -111,7 +111,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 hauler store sync --products rancher=v2.8.3 --key carbide-key.pub --store rancher-store --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store rancher-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ## Longhorn
@@ -128,7 +128,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 hauler store sync --products longhorn=v1.6.1 --key carbide-key.pub --store longhorn-store --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store longhorn-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ## NeuVector
@@ -145,7 +145,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 hauler store sync --products neuvector=v5.3.2 --key carbide-key.pub --store neuvector-store --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store neuvector-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ## Kubewarden
@@ -162,5 +162,5 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 hauler store sync --products kubewarden=kubewarden-controller-2.0.11 --key carbide-key.pub --store kubewarden-store --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store kubewarden-store --username <redacted> --password <redacted> registry://<registry-url>
 ```

--- a/docs/registry-docs/copying-images.md
+++ b/docs/registry-docs/copying-images.md
@@ -38,6 +38,7 @@ EOF
 
 # fetch the content from generated hauler manifest
 # verify the location of the key and the platform/architecture
+# key verification is not used here due to Natsio images not being signed
 hauler store sync --files carbide-images.yaml --store carbide-store --platform <platform/arch>
 
 # copy the content from the hauler store to your registry

--- a/docs/registry-docs/copying-images.md
+++ b/docs/registry-docs/copying-images.md
@@ -39,7 +39,7 @@ EOF
 # fetch the content from generated hauler manifest
 # verify the location of the key and the platform/architecture
 # key verification is not used here due to Natsio images not being signed
-hauler store sync --files carbide-images.yaml --store carbide-store --platform <platform/arch>
+hauler store sync --store carbide-store --files carbide-images.yaml --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
 hauler store copy --store carbide-store --username <redacted> --password <redacted> registry://<registry-url>
@@ -56,7 +56,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products k3s=v1.27.12-k3s1 --key carbide-key.pub --store k3s-store --platform <platform/arch>
+hauler store sync --store k3s-store --products k3s=v1.27.12-k3s1 --key carbide-key.pub --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
 hauler store copy --store k3s-store --username <redacted> --password <redacted> registry://<registry-url>
@@ -73,7 +73,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products rke2=v1.27.12+rke2r1 --key carbide-key.pub --store rke2-store --platform <platform/arch>
+hauler store sync --store rke2-store --products rke2=v1.27.12+rke2r1 --key carbide-key.pub --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
 hauler store copy --store rke2-store --username <redacted> --password <redacted> registry://<registry-url>
@@ -92,7 +92,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products cert-manager=v1.14.4 --key carbide-key.pub --store certmanager-store --platform <platform/arch>
+hauler store sync --store certmanager-store --products cert-manager=v1.14.4 --key carbide-key.pub --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
 hauler store copy --store certmanager-store --username <redacted> --password <redacted> registry://<registry-url>
@@ -109,7 +109,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products rancher=v2.8.3 --key carbide-key.pub --store rancher-store --platform <platform/arch>
+hauler store sync --store rancher-store --products rancher=v2.8.3 --key carbide-key.pub --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
 hauler store copy --store rancher-store --username <redacted> --password <redacted> registry://<registry-url>
@@ -126,7 +126,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products longhorn=v1.6.1 --key carbide-key.pub --store longhorn-store --platform <platform/arch>
+hauler store sync --store longhorn-store --products longhorn=v1.6.1 --key carbide-key.pub --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
 hauler store copy --store longhorn-store --username <redacted> --password <redacted> registry://<registry-url>
@@ -143,7 +143,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products neuvector=v5.3.2 --key carbide-key.pub --store neuvector-store --platform <platform/arch>
+hauler store sync --store neuvector-store --products neuvector=v5.3.2 --key carbide-key.pub --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
 hauler store copy --store neuvector-store --username <redacted> --password <redacted> registry://<registry-url>
@@ -160,7 +160,7 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products kubewarden=kubewarden-controller-2.0.11 --key carbide-key.pub --store kubewarden-store --platform <platform/arch>
+hauler store sync --store kubewarden-store --products kubewarden=kubewarden-controller-2.0.11 --key carbide-key.pub --platform <platform/arch>
 
 # copy the content from the hauler store to your registry
 hauler store copy --store kubewarden-store --username <redacted> --password <redacted> registry://<registry-url>

--- a/docs/registry-docs/downloading-images.md
+++ b/docs/registry-docs/downloading-images.md
@@ -38,10 +38,11 @@ EOF
 
 # fetch the content from generated hauler manifest
 # verify the location of the key and the platform/architecture
-hauler store sync --files carbide-images.yaml --store carbide-store --platform <platform/arch>
+# key verification is not used here due to natsio images not being signed
+hauler store sync --store carbide-store --files carbide-images.yaml --platform <platform/arch>
 
 # save and output the content from the hauler store to tarball
-hauler store save --filename carbide-images.tar.zst
+hauler store save --store carbide-store --filename carbide-images.tar.zst
 ```
 
 ## K3s
@@ -55,10 +56,10 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products k3s=v1.27.12-k3s1 --key carbide-key.pub --store k3s-store --platform <platform/arch>
+hauler store sync --store k3s-store --products k3s=v1.27.12-k3s1 --key carbide-key.pub --platform <platform/arch>
 
 # save and output the content from the hauler store to tarball
-hauler store save --filename k3s-images.tar.zst
+hauler store save --store k3s-store --filename k3s-images.tar.zst
 ```
 
 ## RKE2
@@ -72,10 +73,10 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products rke2=v1.27.12+rke2r1 --key carbide-key.pub --store rke2-store --platform <platform/arch>
+hauler store sync --store rke2-store --products rke2=v1.27.12+rke2r1 --key carbide-key.pub --platform <platform/arch>
 
 # save and output the content from the hauler store to tarball
-hauler store save --filename rke2-images.tar.zst
+hauler store save --store rke2-store --filename rke2-images.tar.zst
 ```
 
 ## Rancher
@@ -91,10 +92,10 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products cert-manager=v1.14.4 --key carbide-key.pub --store certmanager-store --platform <platform/arch>
+hauler store sync --store certmanager-store --products cert-manager=v1.14.4 --key carbide-key.pub --platform <platform/arch>
 
 # save and output the content from the hauler store to tarball
-hauler store save --filename certmanager-images.tar.zst
+hauler store save --store certmanager-store --filename certmanager-images.tar.zst
 ```
 
 ### Rancher
@@ -108,10 +109,10 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products rancher=v2.8.3 --key carbide-key.pub --store rancher-store --platform <platform/arch>
+hauler store sync --store rancher-store --products rancher=v2.8.3 --key carbide-key.pub --platform <platform/arch>
 
 # save and output the content from the hauler store to tarball
-hauler store save --filename rancher-images.tar.zst
+hauler store save --store rancher-store --filename rancher-images.tar.zst
 ```
 
 ## Longhorn
@@ -125,10 +126,10 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products longhorn=v1.6.1 --key carbide-key.pub --store longhorn-store --platform <platform/arch>
+hauler store sync --store longhorn-store --products longhorn=v1.6.1 --key carbide-key.pub --platform <platform/arch>
 
 # save and output the content from the hauler store to tarball
-hauler store save --filename longhorn-images.tar.zst
+hauler store save --store longhorn-store --filename longhorn-images.tar.zst
 ```
 
 ## NeuVector
@@ -142,10 +143,10 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products neuvector=v5.3.2 --key carbide-key.pub --store neuvector-store --platform <platform/arch>
+hauler store sync --store neuvector-store --products neuvector=v5.3.2 --key carbide-key.pub --platform <platform/arch>
 
 # save and output the content from the hauler store to tarball
-hauler store save --filename neuvector-images.tar.zst
+hauler store save --store neuvector-store --filename neuvector-images.tar.zst
 ```
 
 ## Kubewarden
@@ -159,10 +160,10 @@ curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/mai
 
 # fetch the content from the carbide secured registry
 # verify the version, location of the key, and the platform/architecture
-hauler store sync --products kubewarden=kubewarden-controller-2.0.11 --key carbide-key.pub --store kubewarden-store --platform <platform/arch>
+hauler store sync --store kubewarden-store --products kubewarden=kubewarden-controller-2.0.11 --key carbide-key.pub --platform <platform/arch>
 
 # save and output the content from the hauler store to tarball
-hauler store save --filename kubewarden-images.tar.zst
+hauler store save --store kubewarden-store --filename kubewarden-images.tar.zst
 ```
 
 See [Loading Local Images to Registry](loading-images.md) for information on loading the images into your airgapped registry.

--- a/docs/registry-docs/loading-images.md
+++ b/docs/registry-docs/loading-images.md
@@ -8,30 +8,30 @@ Make sure you've checked out the section on [Downloading Images](downloading-ima
 
 ```bash
 # load the content from the tarball to the hauler store
-hauler store load carbide-images.tar.zst
+hauler store load --store carbide-store carbide-images.tar.zst
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store carbide-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ## K3s
 
 ```bash
 # load the content from the tarball to the hauler store
-hauler store load k3s-images.tar.zst
+hauler store load --store k3s-store k3s-images.tar.zst
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store k3s-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ## RKE2
 
 ```bash
 # load the content from the tarball to the hauler store
-hauler store load rke2-images.tar.zst
+hauler store load --store rke2-store rke2-images.tar.zst
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store rke2-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ## Rancher
@@ -40,48 +40,48 @@ hauler store copy --username <redacted> --password <redacted> registry://<regist
 
 ```bash
 # load the content from the tarball to the hauler store
-hauler store load certmanager-images.tar.zst
+hauler store load --store certmanager-store certmanager-images.tar.zst
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store certmanager-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ### Rancher
 
 ```bash
 # load the content from the tarball to the hauler store
-hauler store load rancher-images.tar.zst
+hauler store load --store rancher-store rancher-images.tar.zst
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store rancher-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ## Longhorn
 
 ```bash
 # load the content from the tarball to the hauler store
-hauler store load longhorn-images.tar.zst
+hauler store load --store longhorn-store longhorn-images.tar.zst
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store longhorn-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ## NeuVector
 
 ```bash
 # load the content from the tarball to the hauler store
-hauler store load neuvector-images.tar.zst
+hauler store load --store neuvector-store neuvector-images.tar.zst
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store neuvector-store --username <redacted> --password <redacted> registry://<registry-url>
 ```
 
 ## Kubewarden
 
 ```bash
 # load the content from the tarball to the hauler store
-hauler store load kubewarden-images.tar.zst
+hauler store load --store kubewarden-store kubewarden-images.tar.zst
 
 # copy the content from the hauler store to your registry
-hauler store copy --username <redacted> --password <redacted> registry://<registry-url>
+hauler store copy --store kubewarden-store --username <redacted> --password <redacted> registry://<registry-url>
 ```


### PR DESCRIPTION
All of the products 'hauler store copy' commands were missing '--store' arguments that matched up with the 'hauler store sync' commands.

Also added a note explaining why we're not validating the carbide-key with the actual Carbide images